### PR TITLE
Latvian translation of country "Iceland", it's currency and language updated.

### DIFF
--- a/resources/country/lv.json
+++ b/resources/country/lv.json
@@ -276,7 +276,7 @@
 		"name": "Īrija"
 	},
 	"IS": {
-		"name": "Īslande"
+		"name": "Islande"
 	},
 	"IT": {
 		"name": "Itālija"

--- a/resources/currency/lv.json
+++ b/resources/currency/lv.json
@@ -187,7 +187,7 @@
 		"name": "Irānas riāls"
 	},
 	"ISK": {
-		"name": "Īslandes krona"
+		"name": "Islandes krona"
 	},
 	"ILS": {
 		"name": "Izraēlas šekelis",

--- a/resources/language/lv.json
+++ b/resources/language/lv.json
@@ -195,7 +195,7 @@
 		"name": "īru"
 	},
 	"is": {
-		"name": "īslandiešu"
+		"name": "islandiešu"
 	},
 	"it": {
 		"name": "itāļu"


### PR DESCRIPTION
There has been a long discussion among Latvian linguists which word - `Islande` or `Īslande` - is the best translation of the country `Iceland`, but it appears that historical version `Islande` prevails. Linguistically more correct form of `Īslande` is also allowed, though.

This PR updates translation of `Iceland` to the word which is more widespread (without the macron above `i`).

References:
  - [Wikipedia page about `Iceland` in Latvian](https://lv.wikipedia.org/wiki/Islande) 
  - [Īslande atkal ir Islande (`Īslande` is `Islande` again)](http://www.lvportals.lv/skaidrojumi.php?id=232433) - portal of official publisher of state legislature (again, in Latvian).