### PR TITLE
spanish, euskera, gallego and catalán have the same number_format

### DIFF
--- a/resources/number_format/ca.json
+++ b/resources/number_format/ca.json
@@ -1,9 +1,9 @@
 {
 	"numbering_system": "latn",
 	"decimal_pattern": "#,##0.###",
-	"percent_pattern": "#,##0%",
+	"percent_pattern": "#,##0 %",
 	"currency_pattern": "#,##0.00 ¤",
-	"accounting_currency_pattern": "#,##0.00 ¤;(#,##0.00 ¤)",
+	"accounting_currency_pattern": "#,##0.00 ¤",
 	"decimal_separator": ",",
 	"grouping_separator": "."
 }

--- a/resources/number_format/eu.json
+++ b/resources/number_format/eu.json
@@ -1,9 +1,9 @@
 {
 	"numbering_system": "latn",
 	"decimal_pattern": "#,##0.###",
-	"percent_pattern": "% #,##0",
+	"percent_pattern": "#,##0 %",
 	"currency_pattern": "#,##0.00 ¤",
-	"accounting_currency_pattern": "#,##0.00 ¤;(#,##0.00 ¤)",
+	"accounting_currency_pattern": "#,##0.00 ¤",
 	"decimal_separator": ",",
 	"grouping_separator": "."
 }

--- a/resources/number_format/gl.json
+++ b/resources/number_format/gl.json
@@ -1,9 +1,9 @@
 {
 	"numbering_system": "latn",
 	"decimal_pattern": "#,##0.###",
-	"percent_pattern": "#,##0%",
-	"currency_pattern": "¤#,##0.00",
-	"accounting_currency_pattern": "¤#,##0.00;(¤#,##0.00)",
+	"percent_pattern": "#,##0 %",
+	"currency_pattern": "#,##0.00 ¤",
+	"accounting_currency_pattern": "#,##0.00 ¤",
 	"decimal_separator": ",",
 	"grouping_separator": "."
 }


### PR DESCRIPTION
In catalan, gallego or euskera cultures, we expect the same number format as in spanish es_ES culture, ie:

spanish (es or es_ES): 12,5 €
euskera (eu or eu_ES): 12,5 €
gallego (gl or gl_ES): 12,5 €