### PR TITLE
Allow setting of rendered locales

### DIFF
--- a/src/LocaleResolverTrait.php
+++ b/src/LocaleResolverTrait.php
@@ -14,6 +14,20 @@ trait LocaleResolverTrait
     protected $definitionPath;
 
     /**
+     * The default locale.
+     *
+     * @var string
+     */
+    protected $defaultLocale = 'en';
+
+    /**
+     * The fallback locale.
+     *
+     * @var string
+     */
+    protected $fallbackLocale = null;
+
+    /**
      * Common locale aliases.
      *
      * @var array
@@ -91,6 +105,7 @@ trait LocaleResolverTrait
         // List all possible variants (i.e. en-US gives "en-US" and "en").
         $localeVariants = $this->getLocaleVariants($locale);
         // A fallback locale was provided, add it to the end of the chain.
+        $fallbackLocale = $fallbackLocale ?: $this->getFallbackLocale();
         if (isset($fallbackLocale)) {
             $localeVariants[] = $fallbackLocale;
         }
@@ -168,9 +183,39 @@ trait LocaleResolverTrait
      *
      * @return string The default locale.
      */
-    protected function getDefaultLocale()
+    public function getDefaultLocale()
     {
-        return 'en';
+        return $this->defaultLocale;
+    }
+
+    /**
+     * Sets the default locale.
+     *
+     * @return void
+     */
+    public function setDefaultLocale($locale)
+    {
+        $this->defaultLocale = $locale;
+    }
+
+    /**
+     * Gets the fallback locale.
+     *
+     * @return string The fallback locale.
+     */
+    public function getFallbackLocale()
+    {
+        return $this->fallbackLocale;
+    }
+
+    /**
+     * Sets the fallback locale.
+     *
+     * @return void
+     */
+    public function setFallbackLocale($locale)
+    {
+        $this->fallbackLocale = $locale;
     }
 
     /**

--- a/tests/LocaleResolverTest.php
+++ b/tests/LocaleResolverTest.php
@@ -25,6 +25,34 @@ class LocaleResolverTest extends \PHPUnit_Framework_TestCase
         $this->repository = new DummyRepository();
     }
 
+	/**
+     * @covers ::getDefaultLocale
+     * @covers ::setDefaultLocale
+     *
+     * @uses \CommerceGuys\Intl\LocaleResolverTrait::getDefaultLocale
+     * @uses \CommerceGuys\Intl\LocaleResolverTrait::setDefaultLocale
+     */
+    public function testDefaultLocale()
+    {
+    	$this->assertEquals('en', $this->repository->getDefaultLocale());
+    	$this->repository->setDefaultLocale('fr');
+    	$this->assertEquals('fr', $this->repository->getDefaultLocale());
+    }
+
+    /**
+     * @covers ::getFallbackLocale
+     * @covers ::setFallbackLocale
+     *
+     * @uses \CommerceGuys\Intl\LocaleResolverTrait::getFallbackLocale
+     * @uses \CommerceGuys\Intl\LocaleResolverTrait::setFallbackLocale
+     */
+    public function testFallbackLocale()
+    {
+    	$this->assertNull($this->repository->getFallbackLocale());
+    	$this->repository->setFallbackLocale('en');
+    	$this->assertEquals('en', $this->repository->getFallbackLocale());
+    }
+
     /**
      * @covers ::resolveLocale
      * @covers ::getDefaultLocale


### PR DESCRIPTION
This way the preferred locales can be set upon instantiation of a repository. Particularly useful in Container pattern (Laravel, Symfony) since the locale doesn't have to be provided anymore for each call.