### PR TITLE
Place currency symbol before amount in Belgian format

### DIFF
--- a/resources/number_format/nl-BE.json
+++ b/resources/number_format/nl-BE.json
@@ -2,7 +2,7 @@
 	"numbering_system": "latn",
 	"decimal_pattern": "#,##0.###",
 	"percent_pattern": "#,##0%",
-	"currency_pattern": "#,##0.00 ¤",
+	"currency_pattern": "¤ #,##0.00",
 	"accounting_currency_pattern": "¤ #,##0.00;(¤ #,##0.00)",
 	"decimal_separator": ",",
 	"grouping_separator": "."


### PR DESCRIPTION
In Belgium the Euro symbol is placed before the amount. 

This pull requests changes the place of the symbol for 'nl-BE.json' file.

https://en.wikipedia.org/wiki/Linguistic_issues_concerning_the_euro#Dutch