### PR TITLE
Fatal error fixed when getting not english locale in NumberFormatRepository

### DIFF
--- a/src/NumberFormat/NumberFormatRepository.php
+++ b/src/NumberFormat/NumberFormatRepository.php
@@ -40,7 +40,10 @@ class NumberFormatRepository implements NumberFormatRepositoryInterface
         // The generation script strips all keys that have the same values
         // as the ones in 'en'.
         if ($definition['locale'] != 'en') {
-            $definition += $definition['en'];
+            $definitions = $this->getDefinitions();
+            if (isset($definitions['en'])) {
+                $definition += $definitions['en'];
+            }
         }
 
         return $definition;

--- a/tests/NumberFormat/NumberFormatRepositoryTest.php
+++ b/tests/NumberFormat/NumberFormatRepositoryTest.php
@@ -38,6 +38,10 @@ class NumberFormatRepositoryTest extends \PHPUnit_Framework_TestCase
     public function testGet()
     {
         $numberFormatRepository = new NumberFormatRepository();
+
+        $numberFormat = $numberFormatRepository->get('es');
+        $this->assertEquals('es', $numberFormat->getLocale());
+
         $numberFormat = $numberFormatRepository->get('en');
         $this->assertInstanceOf('CommerceGuys\\Intl\\NumberFormat\\NumberFormat', $numberFormat);
         $this->assertEquals('en', $numberFormat->getLocale());


### PR DESCRIPTION
https://github.com/commerceguys/intl/blob/a5d5cfbc1fe5ad7c7b3d8b870315987527629404/src/NumberFormat/NumberFormatRepository.php#L43

processDefinition method from NumberFormatRepository was throwing "Undefined index: en" when using other parameter different than "en".

I have added some test for validating this too.