### PR TITLE
Add support for currencyGroup and currencyDecimal

### DIFF
--- a/scripts/generate_number_format_data.php
+++ b/scripts/generate_number_format_data.php
@@ -106,8 +106,14 @@ function generate_number_formats()
         if ($decimalSeparator != '.') {
             $numberFormats[$locale]['decimal_separator'] = $decimalSeparator;
         }
+        if (array_key_exists('currencyDecimal', $data['symbols-numberSystem-' . $numberingSystem])) {
+            $numberFormats[$locale]['decimal_currency_separator'] = $data['symbols-numberSystem-' . $numberingSystem]['currencyDecimal'];
+        }
         if ($groupingSeparator != ',') {
             $numberFormats[$locale]['grouping_separator'] = $groupingSeparator;
+        }
+        if (array_key_exists('currencyGroup', $data['symbols-numberSystem-' . $numberingSystem])) {
+            $numberFormats[$locale]['grouping_currency_separator'] = $data['symbols-numberSystem-' . $numberingSystem]['currencyGroup'];
         }
         if ($plusSign != '+') {
             $numberFormats[$locale]['plus_sign'] = $plusSign;

--- a/src/Formatter/CurrencyFormatter.php
+++ b/src/Formatter/CurrencyFormatter.php
@@ -242,7 +242,7 @@ class CurrencyFormatter implements CurrencyFormatterInterface
     /**
      * {@inheritdoc}
      */
-    protected function getLocalizeReplacements(NumberFormat $numberFormat): array
+    protected function getLocalizedSymbols(NumberFormat $numberFormat): array
     {
         return [
             '.' => $numberFormat->getDecimalCurrencySeparator(),
@@ -256,7 +256,7 @@ class CurrencyFormatter implements CurrencyFormatterInterface
     /**
      * {@inheritdoc}
      */
-    protected function getParseReplacements(NumberFormat $numberFormat): array
+    protected function getCanonicalSymbols(NumberFormat $numberFormat): array
     {
         return  [
             $numberFormat->getGroupingCurrencySeparator() => '',

--- a/src/Formatter/CurrencyFormatter.php
+++ b/src/Formatter/CurrencyFormatter.php
@@ -238,4 +238,37 @@ class CurrencyFormatter implements CurrencyFormatterInterface
             throw new InvalidArgumentException(sprintf('Unrecognized currency display "%s".', $options['currency_display']));
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getLocalizeReplacements(NumberFormat $numberFormat): array
+    {
+        return [
+            '.' => $numberFormat->getDecimalCurrencySeparator(),
+            ',' => $numberFormat->getGroupingCurrencySeparator(),
+            '+' => $numberFormat->getPlusSign(),
+            '-' => $numberFormat->getMinusSign(),
+            '%' => $numberFormat->getPercentSign(),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getParseReplacements(NumberFormat $numberFormat): array
+    {
+        return  [
+            $numberFormat->getGroupingCurrencySeparator() => '',
+            // Convert the localized symbols back to their original form.
+            $numberFormat->getDecimalCurrencySeparator() => '.',
+            $numberFormat->getPlusSign() => '+',
+            $numberFormat->getMinusSign() => '-',
+            $numberFormat->getPercentSign() => '%',
+
+            // Strip whitespace (spaces and non-breaking spaces).
+            ' ' => '',
+            chr(0xC2) . chr(0xA0) => '',
+        ];
+    }
 }

--- a/src/Formatter/FormatterTrait.php
+++ b/src/Formatter/FormatterTrait.php
@@ -124,13 +124,7 @@ trait FormatterTrait
             $number = strtr($number, $this->digits[$numberingSystem]);
         }
         // Localize symbols.
-        $replacements = [
-            '.' => $numberFormat->getDecimalSeparator(),
-            ',' => $numberFormat->getGroupingSeparator(),
-            '+' => $numberFormat->getPlusSign(),
-            '-' => $numberFormat->getMinusSign(),
-            '%' => $numberFormat->getPercentSign(),
-        ];
+        $replacements = $this->getLocalizeReplacements($numberFormat);
         $number = strtr($number, $replacements);
 
         return $number;
@@ -149,18 +143,7 @@ trait FormatterTrait
      */
     protected function parseNumber($number, NumberFormat $numberFormat)
     {
-        $replacements = [
-            $numberFormat->getGroupingSeparator() => '',
-            // Convert the localized symbols back to their original form.
-            $numberFormat->getDecimalSeparator() => '.',
-            $numberFormat->getPlusSign() => '+',
-            $numberFormat->getMinusSign() => '-',
-            $numberFormat->getPercentSign() => '%',
-
-            // Strip whitespace (spaces and non-breaking spaces).
-            ' ' => '',
-            chr(0xC2) . chr(0xA0) => '',
-        ];
+        $replacements = $this->getParseReplacements($numberFormat);
         $numberingSystem = $numberFormat->getNumberingSystem();
         if (isset($this->digits[$numberingSystem])) {
             // Convert the localized digits back to latin.
@@ -212,4 +195,49 @@ trait FormatterTrait
      * @return string[] The patterns, keyed by style.
      */
     abstract protected function getAvailablePatterns(NumberFormat $numberFormat);
+
+    /**
+     * Returns the replacements to be used for the localizeNumber method.
+     *
+     * Can be overriden which is useful for deviating symbols for currencies.
+     *
+     * @param NumberFormat $numberFormat
+     *
+     * @return array
+     */
+    protected function getLocalizeReplacements(NumberFormat $numberFormat): array
+    {
+        return [
+            '.' => $numberFormat->getDecimalSeparator(),
+            ',' => $numberFormat->getGroupingSeparator(),
+            '+' => $numberFormat->getPlusSign(),
+            '-' => $numberFormat->getMinusSign(),
+            '%' => $numberFormat->getPercentSign(),
+        ];
+    }
+
+    /**
+     * Returns the replacements to be used for the parseNumber method.
+     *
+     * Can be overriden which is useful for deviating symbols for currencies.
+     *
+     * @param NumberFormat $numberFormat
+     *
+     * @return array
+     */
+    protected function getParseReplacements(NumberFormat $numberFormat): array
+    {
+        return  [
+            $numberFormat->getGroupingSeparator() => '',
+            // Convert the localized symbols back to their original form.
+            $numberFormat->getDecimalSeparator() => '.',
+            $numberFormat->getPlusSign() => '+',
+            $numberFormat->getMinusSign() => '-',
+            $numberFormat->getPercentSign() => '%',
+
+            // Strip whitespace (spaces and non-breaking spaces).
+            ' ' => '',
+            chr(0xC2) . chr(0xA0) => '',
+        ];
+    }
 }

--- a/src/Formatter/FormatterTrait.php
+++ b/src/Formatter/FormatterTrait.php
@@ -124,7 +124,7 @@ trait FormatterTrait
             $number = strtr($number, $this->digits[$numberingSystem]);
         }
         // Localize symbols.
-        $replacements = $this->getLocalizeReplacements($numberFormat);
+        $replacements = $this->getLocalizedSymbols($numberFormat);
         $number = strtr($number, $replacements);
 
         return $number;
@@ -143,7 +143,7 @@ trait FormatterTrait
      */
     protected function parseNumber($number, NumberFormat $numberFormat)
     {
-        $replacements = $this->getParseReplacements($numberFormat);
+        $replacements = $this->getCanonicalSymbols($numberFormat);
         $numberingSystem = $numberFormat->getNumberingSystem();
         if (isset($this->digits[$numberingSystem])) {
             // Convert the localized digits back to latin.
@@ -199,45 +199,18 @@ trait FormatterTrait
     /**
      * Returns the replacements to be used for the localizeNumber method.
      *
-     * Can be overriden which is useful for deviating symbols for currencies.
-     *
      * @param NumberFormat $numberFormat
      *
      * @return array
      */
-    protected function getLocalizeReplacements(NumberFormat $numberFormat): array
-    {
-        return [
-            '.' => $numberFormat->getDecimalSeparator(),
-            ',' => $numberFormat->getGroupingSeparator(),
-            '+' => $numberFormat->getPlusSign(),
-            '-' => $numberFormat->getMinusSign(),
-            '%' => $numberFormat->getPercentSign(),
-        ];
-    }
+    abstract protected function getLocalizedSymbols(NumberFormat $numberFormat): array;
 
     /**
      * Returns the replacements to be used for the parseNumber method.
      *
-     * Can be overriden which is useful for deviating symbols for currencies.
-     *
      * @param NumberFormat $numberFormat
      *
      * @return array
      */
-    protected function getParseReplacements(NumberFormat $numberFormat): array
-    {
-        return  [
-            $numberFormat->getGroupingSeparator() => '',
-            // Convert the localized symbols back to their original form.
-            $numberFormat->getDecimalSeparator() => '.',
-            $numberFormat->getPlusSign() => '+',
-            $numberFormat->getMinusSign() => '-',
-            $numberFormat->getPercentSign() => '%',
-
-            // Strip whitespace (spaces and non-breaking spaces).
-            ' ' => '',
-            chr(0xC2) . chr(0xA0) => '',
-        ];
-    }
+    abstract protected function getCanonicalSymbols(NumberFormat $numberFormat): array;
 }

--- a/src/Formatter/NumberFormatter.php
+++ b/src/Formatter/NumberFormatter.php
@@ -160,4 +160,37 @@ class NumberFormatter implements NumberFormatterInterface
             throw new InvalidArgumentException(sprintf('Unrecognized style "%s".', $options['style']));
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getLocalizedSymbols(NumberFormat $numberFormat): array
+    {
+        return [
+            '.' => $numberFormat->getDecimalSeparator(),
+            ',' => $numberFormat->getGroupingSeparator(),
+            '+' => $numberFormat->getPlusSign(),
+            '-' => $numberFormat->getMinusSign(),
+            '%' => $numberFormat->getPercentSign(),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getCanonicalSymbols(NumberFormat $numberFormat): array
+    {
+        return  [
+            $numberFormat->getGroupingSeparator() => '',
+            // Convert the localized symbols back to their original form.
+            $numberFormat->getDecimalSeparator() => '.',
+            $numberFormat->getPlusSign() => '+',
+            $numberFormat->getMinusSign() => '-',
+            $numberFormat->getPercentSign() => '%',
+
+            // Strip whitespace (spaces and non-breaking spaces).
+            ' ' => '',
+            chr(0xC2) . chr(0xA0) => '',
+        ];
+    }
 }

--- a/src/NumberFormat/NumberFormat.php
+++ b/src/NumberFormat/NumberFormat.php
@@ -68,7 +68,7 @@ final class NumberFormat
     protected $decimalSeparator = '.';
 
     /**
-     * The decimal separator for currency.
+     * The decimal separator for currency amounts.
      *
      * @var string
      */
@@ -82,7 +82,7 @@ final class NumberFormat
     protected $groupingSeparator = ',';
 
     /**
-     * The grouping separator for currency.
+     * The grouping separator for currency amounts.
      *
      * @var string
      */
@@ -251,7 +251,7 @@ final class NumberFormat
     }
 
     /**
-     * Gets the currency decimal separator.
+     * Gets the decimal separator for currency amounts.
      *
      * @return string
      */
@@ -261,7 +261,7 @@ final class NumberFormat
     }
 
     /**
-     * Gets the grouping separator.
+     * Gets the grouping separator for currency amounts.
      *
      * @return string
      */

--- a/src/NumberFormat/NumberFormat.php
+++ b/src/NumberFormat/NumberFormat.php
@@ -68,11 +68,25 @@ final class NumberFormat
     protected $decimalSeparator = '.';
 
     /**
+     * The decimal separator for currency.
+     *
+     * @var string
+     */
+    protected $decimalCurrencySeparator = '.';
+
+    /**
      * The grouping separator.
      *
      * @var string
      */
     protected $groupingSeparator = ',';
+
+    /**
+     * The grouping separator for currency.
+     *
+     * @var string
+     */
+    protected $groupingCurrencySeparator = ',';
 
     /**
      * The plus sign.
@@ -130,8 +144,18 @@ final class NumberFormat
         if (isset($definition['decimal_separator'])) {
             $this->decimalSeparator = $definition['decimal_separator'];
         }
+        if (isset($definition['decimal_currency_separator'])) {
+            $this->decimalCurrencySeparator = $definition['decimal_currency_separator'];
+        } else {
+            $this->decimalCurrencySeparator = $this->decimalSeparator;
+        }
         if (isset($definition['grouping_separator'])) {
             $this->groupingSeparator = $definition['grouping_separator'];
+        }
+        if (isset($definition['grouping_currency_separator'])) {
+            $this->groupingCurrencySeparator = $definition['grouping_currency_separator'];
+        } else {
+            $this->groupingCurrencySeparator = $this->groupingSeparator;
         }
         if (isset($definition['plus_sign'])) {
             $this->plusSign = $definition['plus_sign'];
@@ -227,6 +251,16 @@ final class NumberFormat
     }
 
     /**
+     * Gets the currency decimal separator.
+     *
+     * @return string
+     */
+    public function getDecimalCurrencySeparator()
+    {
+        return $this->decimalCurrencySeparator;
+    }
+
+    /**
      * Gets the grouping separator.
      *
      * @return string
@@ -234,6 +268,16 @@ final class NumberFormat
     public function getGroupingSeparator()
     {
         return $this->groupingSeparator;
+    }
+
+    /**
+     * Gets the currency grouping separator.
+     *
+     * @return string
+     */
+    public function getGroupingCurrencySeparator()
+    {
+        return $this->groupingCurrencySeparator;
     }
 
     /**

--- a/src/NumberFormat/NumberFormatRepository.php
+++ b/src/NumberFormat/NumberFormatRepository.php
@@ -227,6 +227,7 @@ class NumberFormatRepository implements NumberFormatRepositoryInterface
                 'accounting_currency_pattern' => '#,##0.00 ¤',
                 'decimal_separator' => ',',
                 'grouping_separator' => ' ',
+                'grouping_currency_separator' => '.',
             ],
             'de-CH' => [
                 'currency_pattern' => '¤ #,##0.00;¤-#,##0.00',
@@ -476,6 +477,7 @@ class NumberFormatRepository implements NumberFormatRepositoryInterface
                 'currency_pattern' => '#,##0.00 ¤',
                 'accounting_currency_pattern' => '#,##0.00 ¤;(#,##0.00 ¤)',
                 'decimal_separator' => ',',
+                'decimal_currency_separator' => '.',
                 'grouping_separator' => ' ',
             ],
             'fr-LU' => [

--- a/tests/Formatter/CurrencyFormatterTest.php
+++ b/tests/Formatter/CurrencyFormatterTest.php
@@ -197,6 +197,8 @@ final class CurrencyFormatterTest extends TestCase
             ['bn', 'BND', 'standard', '-50.5', '-৫০.৫০BND'],
             ['bn', 'BND', 'accounting', '-50.5', '(৫০.৫০BND)'],
             ['bn', 'BND', 'standard', '500100.05', '৫,০০,১০০.০৫BND'],
+            ['de-AT', 'EUR', 'standard', '-1000.02', '-€ 1.000,02'],
+            ['fr-CH', 'CHF', 'standard', '-1000.02', '-1 000.02 CHF'],
         ];
     }
 

--- a/tests/Formatter/NumberFormatterTest.php
+++ b/tests/Formatter/NumberFormatterTest.php
@@ -163,6 +163,8 @@ final class NumberFormatterTest extends TestCase
             ['en', 'decimal', '5000000.5', '5,000,000.5'],
             ['bn', 'decimal', '-50.5', '-৫০.৫'],
             ['bn', 'decimal', '5000000.5', '৫০,০০,০০০.৫'],
+            ['de-AT', 'decimal', '-5000.00', '-5 000'],
+            ['fr-CH', 'decimal', '-5000.12', '-5 000,12'],
         ];
     }
 


### PR DESCRIPTION
As outlined in #80 , CLDR supports `currencyGroup` and `currencyDecimal` for `de-AT` and `fr-CH`.

This PR adds support for these symbols by extracting the two relevant snippets in `FormatterTrait::localizeNumber()` and `FormatterTrait::parseNumber()` into two methods which are then overridden in `CurrencyFormatter`.

I've also added tests for the two supported locales for both currencies (to ensure it's working) and numbers (to ensure it only affects currencies).

Thank you for this package, I'm happily using it in a few projects!

Let me know if you'd like me to make any changes.