### PR TITLE
Run Travis CI for PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 7.4
   - 7.3
   - 7.2
   - 7.1


### PR DESCRIPTION
When I submitted #82 , I noticed Travis wasn't testing against PHP 7.4. This PR also lists PHP 7.4 (current stable) as test targets for Travis.

Reason why I created a separate PR is to address potential PHP 7.4 failures separately from the new features in my other PR. I hope that's oaky!