### PR TITLE
Fix en-BE currency pattern

### DIFF
--- a/src/NumberFormat/NumberFormatRepository.php
+++ b/src/NumberFormat/NumberFormatRepository.php
@@ -257,8 +257,8 @@ class NumberFormatRepository implements NumberFormatRepositoryInterface
                 'grouping_separator' => '.',
             ],
             'en-BE' => [
-                'currency_pattern' => '#,##0.00 ¤',
-                'accounting_currency_pattern' => '#,##0.00 ¤',
+                'currency_pattern' => '¤#,##0.00',
+                'accounting_currency_pattern' => '¤#,##0.00',
                 'decimal_separator' => ',',
                 'grouping_separator' => '.',
             ],


### PR DESCRIPTION
According to the Europa style guide:
> The euro sign is followed by the amount without space. The same rule applies in Dutch, Irish and Maltese. In all other official EU languages the order is reversed; the amount is followed by a hard space and the euro sign.
https://style-guide.europa.eu/en/content/-/isg/topic?identifier=7.3.3-rules-for-expressing-monetary-units